### PR TITLE
fix: removing unneeded aria-label from TextField's error message span

### DIFF
--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -282,9 +282,7 @@ const TextField: VibeComponent<TextFieldProps, unknown> & {
           {shouldShowExtraText && (
             <Text type={Text.types.TEXT2} color={Text.colors.SECONDARY} className={cx(styles.subTextContainer)}>
               {validation && validation.text && (
-                <span className={cx(styles.subTextContainerStatus)} aria-label={TextFieldAriaLabel.VALIDATION_TEXT}>
-                  {validation.text}
-                </span>
+                <span className={cx(styles.subTextContainerStatus)}>{validation.text}</span>
               )}
               {showCharCount && (
                 <span className={cx(styles.counter)} aria-label={TextFieldAriaLabel.CHAR}>

--- a/src/components/TextField/__tests__/__snapshots__/textField-snapshot-tests.jest.js.snap
+++ b/src/components/TextField/__tests__/__snapshots__/textField-snapshot-tests.jest.js.snap
@@ -1237,7 +1237,6 @@ exports[`TextField renders correctly with validation 1`] = `
       data-testid="text"
     >
       <span
-        aria-label="Additional helper text"
         className="subTextContainerStatus"
       >
         error


### PR DESCRIPTION
Issue fix

Current: there's an unneeded and hardcoded text in the Textfield's error message aria-label.
![image](https://github.com/LihiBechorMarkovitz/monday-ui-react-core/assets/131688148/6187c03f-e4c0-4e02-a732-ff424ac06362)

This fix removed the aria-label from this span. 

#### Tests
- [x] Tests are compliant with [TESTING_README.md](TESTING_README.md) instructions.
