### PR TITLE
feat: add configurable aria-describedby attribute to the link element

### DIFF
--- a/src/components/AlertBanner/__tests__/__snapshots__/AlertBanner-snapshots.jest.js.snap
+++ b/src/components/AlertBanner/__tests__/__snapshots__/AlertBanner-snapshots.jest.js.snap
@@ -165,6 +165,7 @@ exports[`AlertBanner should render with correctly with multiple elements 1`] = `
         data-testid="alert-banner-link"
       >
         <a
+          aria-describedby=""
           aria-label=""
           aria-labelledby=""
           className="link"
@@ -297,6 +298,7 @@ exports[`AlertBanner should render with correctly with text and link 1`] = `
         data-testid="alert-banner-link"
       >
         <a
+          aria-describedby=""
           aria-label=""
           aria-labelledby=""
           className="link"

--- a/src/components/AlertBanner/__tests__/__snapshots__/alertBanner-snapshot-tests.jest.js.snap
+++ b/src/components/AlertBanner/__tests__/__snapshots__/alertBanner-snapshot-tests.jest.js.snap
@@ -148,6 +148,7 @@ exports[`AlertBanner should render with correctly with multiple elements 1`] = `
         data-testid="alert-banner-link"
       >
         <a
+          aria-describedby=""
           aria-label=""
           aria-labelledby=""
           className="link"
@@ -370,6 +371,7 @@ exports[`AlertBanner should render with correctly with text and link 1`] = `
         data-testid="alert-banner-link"
       >
         <a
+          aria-describedby=""
           aria-label=""
           aria-labelledby=""
           className="link"

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -27,6 +27,8 @@ export interface LinkProps extends VibeComponentProps {
   target?: LinkTarget;
   /** Aria label description */
   ariaLabelDescription?: string;
+  /** Identifies the element (or elements) that describes the element on which the attribute is set. */
+  ariaDescribedby?: string;
   /** element id to describe the counter accordingly */
   ariaLabeledBy?: string;
   /** Icon to add to the link element */
@@ -58,6 +60,7 @@ const Link: VibeComponent<LinkProps, HTMLAnchorElement> & {
       onClick = NOOP,
       target = Link.targets.NEW_WINDOW,
       ariaLabelDescription = "",
+      ariaDescribedby = "",
       icon = "",
       iconPosition = Link.position.START,
       id = "",
@@ -96,6 +99,7 @@ const Link: VibeComponent<LinkProps, HTMLAnchorElement> & {
           [styles.inlineText]: inlineText
         })}
         aria-label={ariaLabelDescription}
+        aria-describedby={ariaDescribedby}
         aria-labelledby={ariaLabeledBy}
       >
         {getIcon(isStart, icon, cx(styles.iconStart))}

--- a/src/components/Link/__tests__/__snapshots__/link-snapshot-tests.jest.tsx.snap
+++ b/src/components/Link/__tests__/__snapshots__/link-snapshot-tests.jest.tsx.snap
@@ -1,7 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Link renders correctly with ariaDescribedby 1`] = `
+<a
+  aria-describedby="aria described by"
+  aria-label=""
+  aria-labelledby=""
+  className="link"
+  data-testid="link"
+  href=""
+  id=""
+  onClick={[Function]}
+  rel="noreferrer"
+  target="_blank"
+>
+  <span
+    className="text"
+  >
+    
+  </span>
+</a>
+`;
+
 exports[`Link renders correctly with ariaLabelDescription 1`] = `
 <a
+  aria-describedby=""
   aria-label="arialabel link"
   aria-labelledby=""
   className="link"
@@ -22,6 +44,7 @@ exports[`Link renders correctly with ariaLabelDescription 1`] = `
 
 exports[`Link renders correctly with ariaLabeledBy 1`] = `
 <a
+  aria-describedby=""
   aria-label=""
   aria-labelledby="aria label link"
   className="link"
@@ -42,6 +65,7 @@ exports[`Link renders correctly with ariaLabeledBy 1`] = `
 
 exports[`Link renders correctly with className 1`] = `
 <a
+  aria-describedby=""
   aria-label=""
   aria-labelledby=""
   className="link testClassName"
@@ -62,6 +86,7 @@ exports[`Link renders correctly with className 1`] = `
 
 exports[`Link renders correctly with icon 1`] = `
 <a
+  aria-describedby=""
   aria-label=""
   aria-labelledby=""
   className="link"
@@ -89,6 +114,7 @@ exports[`Link renders correctly with icon 1`] = `
 
 exports[`Link renders correctly with id 1`] = `
 <a
+  aria-describedby=""
   aria-label=""
   aria-labelledby=""
   className="link"
@@ -109,6 +135,7 @@ exports[`Link renders correctly with id 1`] = `
 
 exports[`Link renders correctly with right icon 1`] = `
 <a
+  aria-describedby=""
   aria-label=""
   aria-labelledby=""
   className="link"
@@ -136,6 +163,7 @@ exports[`Link renders correctly with right icon 1`] = `
 
 exports[`Link renders correctly with text 1`] = `
 <a
+  aria-describedby=""
   aria-label=""
   aria-labelledby=""
   className="link"

--- a/src/components/Link/__tests__/link-snapshot-tests.jest.tsx
+++ b/src/components/Link/__tests__/link-snapshot-tests.jest.tsx
@@ -33,6 +33,11 @@ describe("Link renders correctly", () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it("with ariaDescribedby", () => {
+    const tree = renderer.create(<Link ariaDescribedby="aria described by" />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   it("with ariaLabelDescription", () => {
     const tree = renderer.create(<Link ariaLabelDescription="arialabel link" />).toJSON();
     expect(tree).toMatchSnapshot();

--- a/src/components/Toast/__tests__/__snapshots__/toast-snapshot-tests.jest.js.snap
+++ b/src/components/Toast/__tests__/__snapshots__/toast-snapshot-tests.jest.js.snap
@@ -234,6 +234,7 @@ exports[`Toast renders correctly with button and link 1`] = `
   >
     Something Happened
     <a
+      aria-describedby=""
       aria-label=""
       aria-labelledby=""
       className="link actionLink actionLink"
@@ -339,6 +340,7 @@ exports[`Toast renders correctly with link 1`] = `
   >
     Something Happened
     <a
+      aria-describedby=""
       aria-label=""
       aria-labelledby=""
       className="link actionLink actionLink"


### PR DESCRIPTION
Feat
Adding the [aria-describedby](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby) attribute to the `Link` element. 
It can be configured when directly creating a `Link` (not if another element internally uses a `Link`).

#### Tests
- [x] Tests are compliant with [TESTING_README.md](TESTING_README.md) instructions.
